### PR TITLE
Feature/implement Pundit authorization with admin role (issue #5)

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Admin::BaseController < ApplicationController
+  before_action :ensure_admin_access
+
+  private
+
+  def ensure_admin_access
+    authorize :admin_area, :access?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::DashboardController < Admin::BaseController
+  def index
+    # Audit dashboard logic will go here
+  end
+end

--- a/app/policies/admin_area_policy.rb
+++ b/app/policies/admin_area_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AdminAreaPolicy < ApplicationPolicy
+  def access?
+    user&.admin_role? || false
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UserPolicy < ApplicationPolicy
+  def index?
+    user&.admin_role?
+  end
+
+  def show?
+    user&.admin_role? || user == record
+  end
+
+  def create?
+    user&.admin_role?
+  end
+
+  def update?
+    user&.admin_role? || user == record
+  end
+
+  def destroy?
+    user&.admin_role? && user != record
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      if user&.admin_role?
+        scope.all
+      elsif user
+        scope.where(id: user.id)
+      else
+        scope.none
+      end
+    end
+  end
+end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Admin Dashboard" %>
+
+<div class="container mx-auto px-4 py-8">
+  <h1 class="text-3xl font-bold text-gray-900 mb-8">Admin Dashboard</h1>
+  
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-semibold text-gray-800 mb-4">User Management</h2>
+      <p class="text-gray-600">Manage users, roles, and permissions</p>
+    </div>
+    
+    <div class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-semibold text-gray-800 mb-4">Audit Logs</h2>
+      <p class="text-gray-600">View system audit trails and activities</p>
+    </div>
+    
+    <div class="bg-white rounded-lg shadow p-6">
+      <h2 class="text-xl font-semibold text-gray-800 mb-4">System Status</h2>
+      <p class="text-gray-600">Monitor system health and performance</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,12 @@ Rails.application.routes.draw do
     post :regenerate_backup_codes
   end
 
+  # Admin routes
+  namespace :admin do
+    root "dashboard#index"
+    get "dashboard", to: "dashboard#index"
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::DashboardController, type: :controller do
+  describe "GET #index" do
+    context "when user is not logged in" do
+      it "redirects to sign in page" do
+        get :index
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is a regular user" do
+      let(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it "denies access and redirects with authorization error" do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("You are not authorized to perform this action")
+      end
+    end
+
+    context "when user is a staff user" do
+      let(:staff) { create(:user, role: "staff", otp_required_for_login: false) }
+
+      before { sign_in staff }
+
+      it "denies access and redirects with authorization error" do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to include("You are not authorized to perform this action")
+      end
+    end
+
+    context "when user is an admin user" do
+      let(:admin) { create(:user, role: "admin", otp_required_for_login: false) }
+
+      before { sign_in admin }
+
+      it "allows access to admin dashboard" do
+        get :index
+        expect(response).to have_http_status(:success)
+      end
+    end
+  end
+end

--- a/spec/policies/admin_area_policy_spec.rb
+++ b/spec/policies/admin_area_policy_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AdminAreaPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { create(:user) }
+  let(:staff) { create(:user, :staff) }
+  let(:admin) { create(:user, :admin) }
+  let(:admin_area) { :admin_area }
+
+  permissions :access? do
+    context "for a regular user" do
+      it "denies access" do
+        expect(subject).not_to permit(user, admin_area)
+      end
+    end
+
+    context "for a staff user" do
+      it "denies access" do
+        expect(subject).not_to permit(staff, admin_area)
+      end
+    end
+
+    context "for an admin user" do
+      it "grants access" do
+        expect(subject).to permit(admin, admin_area)
+      end
+    end
+
+    context "for an unauthenticated user" do
+      it "denies access" do
+        expect(subject).not_to permit(nil, admin_area)
+      end
+    end
+  end
+end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { create(:user) }
+  let(:record) { double }
+
+  permissions :index?, :show?, :create?, :new?, :update?, :edit?, :destroy? do
+    it "denies all actions by default" do
+      expect(subject).not_to permit(user, record)
+    end
+  end
+
+  describe "Scope" do
+    it "raises NoMethodError when resolve is not implemented" do
+      scope = ApplicationPolicy::Scope.new(user, double)
+
+      expect { scope.resolve }.to raise_error(NoMethodError, /You must define #resolve/)
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserPolicy, type: :policy do
+  subject { described_class }
+
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:staff) { create(:user, :staff) }
+  let(:admin) { create(:user, :admin) }
+
+  permissions :index? do
+    context "for a regular user" do
+      it "denies access" do
+        expect(subject).not_to permit(user, User)
+      end
+    end
+
+    context "for a staff user" do
+      it "denies access" do
+        expect(subject).not_to permit(staff, User)
+      end
+    end
+
+    context "for an admin user" do
+      it "grants access" do
+        expect(subject).to permit(admin, User)
+      end
+    end
+  end
+
+  permissions :show? do
+    context "for a regular user" do
+      it "allows viewing their own profile" do
+        expect(subject).to permit(user, user)
+      end
+
+      it "denies viewing other users' profiles" do
+        expect(subject).not_to permit(user, other_user)
+      end
+    end
+
+    context "for an admin user" do
+      it "allows viewing any user profile" do
+        expect(subject).to permit(admin, user)
+        expect(subject).to permit(admin, other_user)
+      end
+    end
+  end
+
+  permissions :create? do
+    context "for a regular user" do
+      it "denies access" do
+        expect(subject).not_to permit(user, User)
+      end
+    end
+
+    context "for an admin user" do
+      it "grants access" do
+        expect(subject).to permit(admin, User)
+      end
+    end
+  end
+
+  permissions :update? do
+    context "for a regular user" do
+      it "allows updating their own profile" do
+        expect(subject).to permit(user, user)
+      end
+
+      it "denies updating other users' profiles" do
+        expect(subject).not_to permit(user, other_user)
+      end
+    end
+
+    context "for an admin user" do
+      it "allows updating any user profile" do
+        expect(subject).to permit(admin, user)
+        expect(subject).to permit(admin, other_user)
+      end
+    end
+  end
+
+  permissions :destroy? do
+    context "for a regular user" do
+      it "denies deleting their own account" do
+        expect(subject).not_to permit(user, user)
+      end
+
+      it "denies deleting other users' accounts" do
+        expect(subject).not_to permit(user, other_user)
+      end
+    end
+
+    context "for an admin user" do
+      it "allows deleting other users' accounts" do
+        expect(subject).to permit(admin, user)
+      end
+
+      it "denies deleting their own account" do
+        expect(subject).not_to permit(admin, admin)
+      end
+    end
+  end
+
+  describe "Scope" do
+    subject { UserPolicy::Scope.new(current_user, User.all) }
+
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let!(:admin_user) { create(:user, :admin) }
+
+    context "for a regular user" do
+      let(:current_user) { user1 }
+
+      it "scopes to only the current user" do
+        expect(subject.resolve).to contain_exactly(user1)
+      end
+    end
+
+    context "for an admin user" do
+      let(:current_user) { admin_user }
+
+      it "returns all users" do
+        expect(subject.resolve).to contain_exactly(user1, user2, admin_user)
+      end
+    end
+
+    context "for an unauthenticated user" do
+      let(:current_user) { nil }
+
+      it "returns an empty scope" do
+        expect(subject.resolve).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/admin_authorization_spec.rb
+++ b/spec/requests/admin_authorization_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Authorization - Issue Requirements", type: :model do
+  describe "user_denied_admin_area" do
+    context "when a regular user tries to access admin area" do
+      let(:user) { create(:user) }
+
+      it "is denied by AdminAreaPolicy" do
+        policy = AdminAreaPolicy.new(user, :admin_area)
+        expect(policy.access?).to be false
+      end
+    end
+
+    context "when a staff user tries to access admin area" do
+      let(:staff) { create(:user, :staff) }
+
+      it "is denied by AdminAreaPolicy" do
+        policy = AdminAreaPolicy.new(staff, :admin_area)
+        expect(policy.access?).to be false
+      end
+    end
+
+    context "when an unauthenticated user tries to access admin area" do
+      it "is denied by AdminAreaPolicy" do
+        policy = AdminAreaPolicy.new(nil, :admin_area)
+        expect(policy.access?).to be false
+      end
+    end
+  end
+
+  describe "admin_can_manage_audit_dashboard" do
+    context "when an admin user accesses the audit dashboard" do
+      let(:admin) { create(:user, :admin) }
+
+      it "is allowed by AdminAreaPolicy" do
+        policy = AdminAreaPolicy.new(admin, :admin_area)
+        expect(policy.access?).to be true
+      end
+
+      it "can access UserPolicy index action" do
+        policy = UserPolicy.new(admin, User)
+        expect(policy.index?).to be true
+      end
+
+      it "can manage other users" do
+        other_user = create(:user)
+        policy = UserPolicy.new(admin, other_user)
+        expect(policy.show?).to be true
+        expect(policy.update?).to be true
+        expect(policy.destroy?).to be true
+      end
+    end
+  end
+
+  describe "policy_scope_scopes_to_owner" do
+    let!(:user1) { create(:user, email: "user1@example.com") }
+    let!(:user2) { create(:user, email: "user2@example.com") }
+    let!(:admin_user) { create(:user, :admin, email: "admin@example.com") }
+
+    context "when a regular user queries the scope" do
+      it "only returns their own user record" do
+        policy_scope = UserPolicy::Scope.new(user1, User.all)
+
+        expect(policy_scope.resolve).to contain_exactly(user1)
+      end
+    end
+
+    context "when an admin queries the scope" do
+      it "returns all user records" do
+        policy_scope = UserPolicy::Scope.new(admin_user, User.all)
+
+        expect(policy_scope.resolve).to contain_exactly(user1, user2, admin_user)
+      end
+    end
+
+    context "when an unauthenticated user queries the scope" do
+      it "returns an empty scope" do
+        policy_scope = UserPolicy::Scope.new(nil, User.all)
+
+        expect(policy_scope.resolve).to be_empty
+      end
+    end
+  end
+end

--- a/spec/support/pundit.rb
+++ b/spec/support/pundit.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "pundit/rspec"

--- a/spec/system/admin_authorization_spec.rb
+++ b/spec/system/admin_authorization_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Admin Authorization", type: :system do
+  describe "user_denied_admin_area" do
+    context "when a regular user tries to access admin area" do
+      let(:user) { create(:user) }
+
+      it "denies access and redirects with error message" do
+        sign_in user
+        visit admin_root_path
+
+        expect(current_path).to eq(root_path)
+        expect(page).to have_content("You are not authorized to perform this action")
+      end
+    end
+
+    context "when a staff user tries to access admin area" do
+      let(:staff) { create(:user, role: "staff", otp_required_for_login: false) }
+
+      it "denies access and redirects with error message" do
+        sign_in staff
+        visit admin_root_path
+
+        expect(current_path).to eq(root_path)
+        expect(page).to have_content("You are not authorized to perform this action")
+      end
+    end
+  end
+
+  describe "admin_can_manage_audit_dashboard" do
+    context "when an admin user accesses the audit dashboard" do
+      let(:admin) { create(:user, role: "admin", otp_required_for_login: false) }
+
+      it "allows access to the admin dashboard" do
+        sign_in admin
+        visit admin_dashboard_path
+
+        expect(current_path).to eq(admin_dashboard_path)
+        expect(page).to have_content("Admin Dashboard")
+      end
+
+      it "allows access to the admin root" do
+        sign_in admin
+        visit admin_root_path
+
+        expect(current_path).to eq(admin_root_path)
+        expect(page).to have_content("Admin Dashboard")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces an admin area to the application, including new controllers, policies, routes, views, and comprehensive test coverage. The main goal is to restrict access to admin functionality to users with the admin role, enforce authorization checks, and provide a basic admin dashboard interface.

**Admin area implementation and access control:**

* Added `Admin::BaseController` and `Admin::DashboardController`, with a `before_action` to ensure only users with the admin role can access admin routes. (`app/controllers/admin/base_controller.rb`, `app/controllers/admin/dashboard_controller.rb`) [[1]](diffhunk://#diff-899586ef64442e1c0be4149538758cc696ccc8ecf7fb94cdb449809bad79bd6eR1-R11) [[2]](diffhunk://#diff-adc7e857a80c568a183a7b17d30163292d709e6e73a802862fdb4ef314f56449R1-R7)
* Created `AdminAreaPolicy` to define access rules for the admin area, restricting access to users with the admin role. (`app/policies/admin_area_policy.rb`)
* Updated routes to include a new `admin` namespace with dashboard endpoints. (`config/routes.rb`)

**Authorization policies and user management:**

* Implemented `UserPolicy` to control which actions admins and regular users can perform on user resources, including index, show, create, update, and destroy, with a custom scope for user visibility. (`app/policies/user_policy.rb`)
* Added a styled admin dashboard view with sections for user management, audit logs, and system status. (`app/views/admin/dashboard/index.html.erb`)

**Test coverage for admin area and policies:**

* Added controller, policy, model, and system specs to verify admin area access control, policy enforcement, and dashboard functionality for different user roles. (`spec/controllers/admin/dashboard_controller_spec.rb`, `spec/policies/admin_area_policy_spec.rb`, `spec/policies/application_policy_spec.rb`, `spec/policies/user_policy_spec.rb`, `spec/requests/admin_authorization_spec.rb`, `spec/system/admin_authorization_spec.rb`, `spec/support/pundit.rb`) [[1]](diffhunk://#diff-60318f2ca424fc1a724d05bee95faa588c59b16642123589a671269c3c05d9e7R1-R49) [[2]](diffhunk://#diff-80ee6a692f6f19d3e9c75ef13237f809c4d09a0f2e3720ac814d9c8e65f3aa7fR1-R38) [[3]](diffhunk://#diff-850c5c8630943ac15a0542103467afea95e343d8608332564cd445824a7d98d6R1-R24) [[4]](diffhunk://#diff-6394639d588e262f475dceaac4f4e816616b07d106ffddd570b2deb7683fc2bdR1-R138) [[5]](diffhunk://#diff-90c31a8572f72a06f6fc8758e8a9d2f2abf27c4c56ffa43432d5d90544ed4f72R1-R86) [[6]](diffhunk://#diff-cca511c244163168baafd47d9c9ca53d293f2e4342e8d73cc70f88fd2b782b04R1-R53) [[7]](diffhunk://#diff-d0d67167563f06f9d9e433e59ab8e2173275c9c3262786ffdd63aa22a453d87cR1-R3)