### PR TITLE
Feature: complete stub identity capture with local storage (#7)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,12 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+
+  # Preview emails in the browser instead of sending them [https://github.com/ryanb/letter_opener]
+  gem "letter_opener"
+
+  # Web interface for letter_opener [https://github.com/fgrehm/letter_opener_web]
+  gem "letter_opener_web"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     chunky_png (1.4.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
@@ -169,6 +171,17 @@ GEM
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -432,6 +445,8 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kamal
+  letter_opener
+  letter_opener_web
   pg (~> 1.1)
   pg_search
   propshaft

--- a/app/views/kyc/submissions/new.html.erb
+++ b/app/views/kyc/submissions/new.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <%= form_with(url: kyc_path, method: :post, local: true, multipart: true, 
-                  class: "space-y-6", data: { turbo_frame: "kyc_form" }) do |form| %>
+                  class: "space-y-6", scope: :kyc) do |form| %>
       
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,9 @@ Rails.application.configure do
   # Make template changes take effect immediately.
   config.action_mailer.perform_caching = false
 
+  # Use letter_opener_web to preview emails in the browser
+  config.action_mailer.delivery_method = :letter_opener_web
+
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,11 @@ Rails.application.routes.draw do
     post :simulate_decision, on: :member
   end
 
+  # Letter Opener routes (development only)
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
This pull request introduces improvements to email delivery and preview in the development environment, making it easier for developers to test and debug outgoing emails. It also includes a minor form configuration update.

**Email delivery and preview enhancements:**

* Added the `letter_opener` and `letter_opener_web` gems to the development group in `Gemfile` to enable email previews in the browser.
* Configured `config/environments/development.rb` to use `letter_opener_web` as the email delivery method, allowing emails to be previewed instead of sent.
* Mounted the `LetterOpenerWeb::Engine` at `/letter_opener` in `config/routes.rb` for development, providing a web interface for viewing sent emails.

**Form configuration update:**

* Changed the `form_with` helper in `app/views/kyc/submissions/new.html.erb` to use the `scope: :kyc` option, improving form parameter handling.