### PR TITLE
project assumptions conventions v2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,19 @@ inherit_gem: { rubocop-rails-omakase: rubocop.yml }
 # # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
 # Layout/SpaceInsideArrayLiteralBrackets:
 #   Enabled: false
+
+# Prevent deprecated status code usage
+Lint/DeprecatedConstants:
+  Enabled: true
+
+# Custom rule to prevent deprecated HTTP status codes
+Style/HashSyntax:
+  Enabled: true
+
+# Add specific rule to catch deprecated status codes
+Naming/InclusiveLanguage:
+  Enabled: true
+  FlaggedTerms:
+    unprocessable_entity:
+      Suggestions:
+        - unprocessable_content

--- a/app/controllers/api/loans/disbursements_controller.rb
+++ b/app/controllers/api/loans/disbursements_controller.rb
@@ -20,7 +20,7 @@ class Api::Loans::DisbursementsController < ApplicationController
 
     # Verify loan is in approved state
     unless @loan.state_approved?
-      render json: { error: "Loan must be approved to disburse" }, status: :unprocessable_entity
+      render json: { error: "Loan must be approved to disburse" }, status: :unprocessable_content
       return
     end
 
@@ -35,7 +35,7 @@ class Api::Loans::DisbursementsController < ApplicationController
     render json: disbursement_response(@loan), status: :created
 
   rescue Loans::Services::LoanState::InvalidStateTransitionError => e
-    render json: { error: e.message }, status: :unprocessable_entity
+    render json: { error: e.message }, status: :unprocessable_content
   rescue => e
     render json: { error: "Internal server error" }, status: :internal_server_error
   end
@@ -69,7 +69,7 @@ class Api::Loans::DisbursementsController < ApplicationController
     @idempotency_key = request.headers["Idempotency-Key"]
 
     if @idempotency_key.blank?
-      render json: { error: "Idempotency-Key header is required" }, status: :unprocessable_entity
+      render json: { error: "Idempotency-Key header is required" }, status: :unprocessable_content
     end
   end
 

--- a/docs/assumptions.md
+++ b/docs/assumptions.md
@@ -31,33 +31,43 @@ This document outlines the core assumptions and conventions for the eLMo (Loan M
 
 ### Money Storage & Precision
 
-- **Data Type**: `integer` for monetary values (stored in cents)
+- **Storage Format**: `integer` for monetary values (stored in cents)
 - **Currency**: Primarily Philippine Peso (PHP)
-- **Storage**: Monetary values stored in cents (integer)
-- **Precision**: Calculations should use 4 decimal places for accuracy (use `BigDecimal` for all financial calculations)
+- **Precision**: Store amounts as **integer cents**; use **BigDecimal** for mathematical operations
+- **Calculation Standard**: All financial calculations use BigDecimal with 4 decimal places minimum for accuracy
+- **Interest & Ratios**: Store interest rates and ratios as decimals (e.g., 0.15 for 15%)
+- **Rounding**: Apply banker's rounding (half-even) consistently across all monetary calculations
 
 ### Rounding & Calculations
 
-- **Rounding Method**: Banker's rounding (round half to even)
+- **Rounding Method**: Banker's rounding (half-even) for all financial calculations
+- **Interest & Ratios**: Store and calculate interest rates and ratios as decimals (not percentages)
 - **Interest Calculation**: Per product-specific rules (see loan product documentation)
 - **Pro-rating**: Based on actual term_days for accurate daily calculations
-- **Implementation**: Use `BigDecimal` for all financial calculations
-- **Credit Scoring**: Canonical range 300-950 (aligned with TransUnion Philippines CreditVision)
+- **Implementation**: Use `BigDecimal` for all financial calculations to ensure precision
+- **Credit Scoring**:
+  - **Canonical internal range**: 300–950 (TransUnion Philippines aligned)
+  - **Partner/vendor scores**: Normalized to canonical range on data ingest
+  - **Score Updates**: Real-time normalization from external bureau responses
 
 ## API Design & Reliability
 
 ### Idempotency
 
 - **Requirement**: All mutable endpoints MUST require an "Idempotency-Key" header
-- **Key Format**: UUID v4 recommended
-- **Deduplication**: Webhooks deduplicated by provider event ID
-- **Storage**: Use `idempotency_keys` table for tracking
+- **Key Format**: UUID v4 recommended for uniqueness
+- **Deduplication**: Webhooks deduplicated by provider event ID (provider-specific)
+- **Storage**: Use `idempotency_keys` table for comprehensive tracking
+- **Timeout**: Idempotency keys expire after 24 hours
+- **Conflict Resolution**: Return same response for duplicate requests within timeout window
 
 ### Rate Limiting
 
-- **Login Endpoints**: Rate limited per IP address and email
-- **Webhook Ingestion**: Rate limited per provider specification
-- **Implementation**: Use Rack::Attack for rate limiting
+- **Login Endpoints**: Rate limited per IP address and email address
+- **Webhook Ingestion**: Rate limited per provider specification (varies by vendor)
+- **API Endpoints**: Standard rate limits applied to prevent abuse
+- **Implementation**: Use Rack::Attack for comprehensive rate limiting strategy
+- **Monitoring**: Track rate limit violations for security analysis
 
 ## Event-Driven Architecture
 
@@ -109,10 +119,10 @@ end
 
 ### Environments
 
-- **Development**: Local development with hot reloading
-- **Test**: Automated testing with parallel execution
-- **Staging**: Production-like environment for pre-deployment testing
-- **Production**: Live environment with full monitoring and logging
+- **Development (`dev`)**: Local development with hot reloading and detailed logging
+- **Test (`test`)**: Automated testing with parallel execution and isolated data
+- **Staging (`staging`)**: Production-like environment for pre-deployment validation
+- **Production (`prod`)**: Live environment with full monitoring, logging, and security
 
 ### Configuration Management
 
@@ -222,4 +232,5 @@ end
 
 ## Version History
 
+- **v2.0** (2025-09-19): Enhanced specifications for banker's rounding, TransUnion PH credit score alignment, detailed money handling, improved idempotency and rate limiting specificity
 - **v1.0** (2025-09-02): Initial assumptions and conventions document

--- a/spec/requests/disbursement_stub_spec.rb
+++ b/spec/requests/disbursement_stub_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Disbursement Stub API", type: :request do
 
         post "/api/loans/#{approved_loan.id}/disburse"
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json_response = JSON.parse(response.body)
         expect(json_response["error"]).to include("Idempotency-Key header is required")
       end
@@ -179,7 +179,7 @@ RSpec.describe "Disbursement Stub API", type: :request do
         post "/api/loans/#{pending_loan.id}/disburse",
              headers: { "Idempotency-Key" => "pending-key" }
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         json_response = JSON.parse(response.body)
         expect(json_response["error"]).to include("must be approved")
       end


### PR DESCRIPTION
This pull request updates the handling of HTTP status codes throughout the loan disbursement API to replace the deprecated `:unprocessable_entity` status with the new `:unprocessable_content` status. It also improves code quality by introducing new RuboCop rules and enhances documentation for financial calculations, API reliability, and environment conventions.

**HTTP Status Code Modernization:**

* Replaced all instances of `:unprocessable_entity` with `:unprocessable_content` in the `app/controllers/api/loans/disbursements_controller.rb` to use the updated status code for error responses. [[1]](diffhunk://#diff-6a8297f100a0d8b145d07ac8fa62a086f86cb0dea4220ef3a34abfa1b6037e67L23-R23) [[2]](diffhunk://#diff-6a8297f100a0d8b145d07ac8fa62a086f86cb0dea4220ef3a34abfa1b6037e67L38-R38) [[3]](diffhunk://#diff-6a8297f100a0d8b145d07ac8fa62a086f86cb0dea4220ef3a34abfa1b6037e67L72-R72)
* Updated request specs in `spec/requests/disbursement_stub_spec.rb` to expect `:unprocessable_content` instead of `:unprocessable_entity`. [[1]](diffhunk://#diff-a49ddf1cedeffd79e4e204d08298bf937b7689f597d762ccd52689db0578aec1L170-R170) [[2]](diffhunk://#diff-a49ddf1cedeffd79e4e204d08298bf937b7689f597d762ccd52689db0578aec1L182-R182)

**Code Quality and Linting:**

* Added new RuboCop rules in `.rubocop.yml` to enforce the use of non-deprecated constants, inclusive language, and preferred hash syntax. Specifically, flagged `unprocessable_entity` as deprecated and suggested `unprocessable_content` as the replacement.

**Documentation Improvements:**

* Enhanced `docs/assumptions.md` to clarify money storage, precision, rounding methods, idempotency handling, rate limiting strategies, environment naming conventions, and version history. Notable additions include specifying banker's rounding, canonical credit score normalization, idempotency key expiration, and comprehensive rate limiting and monitoring. [[1]](diffhunk://#diff-2a48bd7bad40d31cff09e6ee9a20da82556a7e33035ed9d7f1c85662255ae322L34-R70) [[2]](diffhunk://#diff-2a48bd7bad40d31cff09e6ee9a20da82556a7e33035ed9d7f1c85662255ae322L112-R125) [[3]](diffhunk://#diff-2a48bd7bad40d31cff09e6ee9a20da82556a7e33035ed9d7f1c85662255ae322R235)