### PR TITLE
Add turbo and faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "puma", ">= 5.0"
 gem "jsbundling-rails"
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
+# Hotwire Turbo for reactive frontend [https://github.com/hotwired/turbo-rails]
+gem "turbo-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
@@ -105,4 +107,7 @@ group :test do
 
   # Shoulda matchers for cleaner model and controller tests
   gem "shoulda-matchers"
+
+  # A library for generating fake data [https://github.com/faker-ruby/faker]
+  gem "faker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faker (3.5.2)
+      i18n (>= 1.8.11, < 2)
     fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -397,6 +399,9 @@ GEM
     thruster (0.1.15-aarch64-linux)
     thruster (0.1.15-x86_64-linux)
     timeout (0.4.3)
+    turbo-rails (2.0.16)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.5)
@@ -442,6 +447,7 @@ DEPENDENCIES
   devise
   devise-two-factor
   factory_bot_rails
+  faker
   jbuilder
   jsbundling-rails
   kamal
@@ -464,6 +470,7 @@ DEPENDENCIES
   solid_cache
   solid_queue
   thruster
+  turbo-rails
   tzinfo-data
   web-console
 


### PR DESCRIPTION
This pull request updates the `Gemfile` to add new dependencies for frontend interactivity and improved test data generation. These changes enhance the application's capabilities both in user experience and testing.

**Frontend enhancements:**
* Added the `turbo-rails` gem for Hotwire Turbo, enabling reactive frontend features in Rails applications.

**Testing improvements:**
* Added the `faker` gem to the test group, allowing for easy generation of fake data in tests.