### PR TITLE
Add enum alias, and fix bigdecimal

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -49,11 +49,11 @@ class Payment < ApplicationRecord
 
   # Money methods
   def amount_in_pesos
-    amount_cents / 100.0
+    BigDecimal(amount_cents) / 100
   end
 
   def amount_in_pesos=(amount)
-    self.amount_cents = (amount.to_f * 100).to_i
+    self.amount_cents = (BigDecimal(amount.to_s) * 100).to_i
   end
 
   # State predicates

--- a/app/models/promo_code.rb
+++ b/app/models/promo_code.rb
@@ -21,10 +21,15 @@
 #  index_promo_codes_on_ends_at             (ends_at)
 #
 class PromoCode < ApplicationRecord
+  include EnumAliases
+
   has_many :referrals, dependent: :nullify
 
   # Enums
   enum :kind, { referral: "referral", discount: "discount" }, suffix: true
+
+  # Create unprefixed aliases for kind predicates (e.g., referral?, discount?)
+  alias_unprefixed_enum_predicates :kind
 
   # Validations
   validates :code, presence: true, uniqueness: true, format: { with: /\A[A-Z0-9]+\z/, message: "must contain only uppercase letters and numbers" }
@@ -42,12 +47,12 @@ class PromoCode < ApplicationRecord
 
   # Money methods
   def value_in_pesos
-    return 0 unless value_cents
-    value_cents / 100.0
+    return BigDecimal(0) unless value_cents
+    BigDecimal(value_cents) / 100
   end
 
   def value_in_pesos=(amount)
-    self.value_cents = amount ? (amount.to_f * 100).to_i : nil
+    self.value_cents = amount ? (BigDecimal(amount.to_s) * 100).to_i : nil
   end
 
   # State predicates

--- a/app/models/referral.rb
+++ b/app/models/referral.rb
@@ -25,12 +25,17 @@
 #  fk_rails_...  (referrer_id => users.id)
 #
 class Referral < ApplicationRecord
+  include EnumAliases
+
   belongs_to :referrer, class_name: "User"
   belongs_to :referee, class_name: "User"
   belongs_to :promo_code, optional: true
 
   # Enums
   enum :status, { pending: "pending", rewarded: "rewarded" }, suffix: true
+
+  # Create unprefixed aliases for status predicates (e.g., pending?, rewarded?)
+  alias_unprefixed_enum_predicates :status
 
   # Validations
   validates :status, presence: true, inclusion: { in: statuses.keys }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,11 +169,11 @@ class User < ApplicationRecord
   end
 
   def credit_limit_in_pesos
-    credit_limit_cents / 100.0
+    BigDecimal(credit_limit_cents) / 100
   end
 
   def credit_limit_in_pesos=(amount)
-    self.credit_limit_cents = (amount.to_f * 100).to_i
+    self.credit_limit_cents = (BigDecimal(amount.to_s) * 100).to_i
   end
 
   # KYC methods


### PR DESCRIPTION
This pull request focuses on improving the handling of monetary values and enum predicates in several model classes. The most important changes include switching monetary conversions to use `BigDecimal` for better precision and adding unprefixed enum predicate methods for easier readability and usage.

**Monetary value precision improvements:**

* Updated methods that convert `*_cents` fields to pesos in `Payment`, `PromoCode`, and `User` models to use `BigDecimal` instead of floating-point arithmetic, ensuring more accurate financial calculations. [[1]](diffhunk://#diff-81c4948f81e13d5b8161692b5201740a8c2d9b050576240db5f3df4edfb7d800L52-R56) [[2]](diffhunk://#diff-02ce80b7377b7537edb47606c3296b69253fd751d50f5e3ca6a35e35c8c51521L45-R55) [[3]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bL172-R176)
* Updated setter methods for monetary fields to use `BigDecimal` for conversion, improving consistency and precision when assigning values. [[1]](diffhunk://#diff-81c4948f81e13d5b8161692b5201740a8c2d9b050576240db5f3df4edfb7d800L52-R56) [[2]](diffhunk://#diff-02ce80b7377b7537edb47606c3296b69253fd751d50f5e3ca6a35e35c8c51521L45-R55) [[3]](diffhunk://#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29bL172-R176)

**Enum predicate usability enhancements:**

* Added the `EnumAliases` module to `PromoCode` and `Referral` models and used `alias_unprefixed_enum_predicates` to create unprefixed enum predicate methods (e.g., `referral?`, `discount?`, `pending?`, `rewarded?`), making the codebase easier to read and maintain. [[1]](diffhunk://#diff-02ce80b7377b7537edb47606c3296b69253fd751d50f5e3ca6a35e35c8c51521R24-R33) [[2]](diffhunk://#diff-68937843f8164e0ba034f7f5f630953491f9448abc5aa06b0d9a86d0a479734dR28-R39)