### PR TITLE
Modify event name to user.kyc.approved.v1

### DIFF
--- a/app/controllers/admin/kyc_reviews_controller.rb
+++ b/app/controllers/admin/kyc_reviews_controller.rb
@@ -24,7 +24,7 @@ class Admin::KycReviewsController < Admin::BaseController
 
       # Publish outbox event for approved KYC
       OutboxEvent.publish!(
-        name: "kyc.approved.v1",
+        name: "user.kyc_approved.v1",
         aggregate: @user,
         payload: {
           user_id: @user.id,

--- a/app/controllers/kyc/submissions_controller.rb
+++ b/app/controllers/kyc/submissions_controller.rb
@@ -105,7 +105,7 @@ module Kyc
       if decision == "approved"
         # Publish outbox event for approved KYC
         OutboxEvent.publish!(
-          name: "kyc.approved.v1",
+          name: "user.kyc_approved.v1",
           aggregate: @user,
           payload: {
             user_id: @user.id,

--- a/spec/integration/kyc_simulator_spec.rb
+++ b/spec/integration/kyc_simulator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "KYC Simulator Integration", type: :request do
         }.to change { OutboxEvent.count }.by(1)
 
         event = OutboxEvent.last
-        expect(event.name).to eq("kyc.approved.v1")
+        expect(event.name).to eq("user.kyc_approved.v1")
         expect(event.aggregate_type).to eq("User")
         expect(event.aggregate_id).to eq(user.id)
         expect(event.payload).to include(

--- a/spec/requests/admin/kyc_reviews_spec.rb
+++ b/spec/requests/admin/kyc_reviews_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Admin::KycReviews", type: :request do
 
         # Check that outbox event was created
         event = OutboxEvent.last
-        expect(event.name).to eq("kyc.approved.v1")
+        expect(event.name).to eq("user.kyc_approved.v1")
         expect(event.payload["approved_by"]).to eq(admin_user.id)
       end
     end


### PR DESCRIPTION
This pull request updates the naming convention for KYC approval outbox events across controllers and tests, and adds a new test to ensure sensitive government ID information is properly masked in user payloads. The changes improve event clarity and strengthen data privacy.

**Event Naming Consistency**

* Changed the outbox event name from `"kyc.approved.v1"` to `"user.kyc_approved.v1"` in both the admin and user KYC approval flows (`app/controllers/admin/kyc_reviews_controller.rb`, `app/controllers/kyc/submissions_controller.rb`). [[1]](diffhunk://#diff-d68df80200434076761b0569b1894b5d86c4d1cde66c4db8d4b063df921e84fdL27-R27) [[2]](diffhunk://#diff-c8e2152b305eb9f25c12e9218946887449de47a769a4def09296b1c8f824bdb0L108-R108)
* Updated all related tests to expect the new event name, ensuring consistency throughout the codebase (`spec/integration/kyc_simulator_spec.rb`, `spec/requests/admin/kyc_reviews_spec.rb`, `spec/requests/kyc/submissions_spec.rb`). [[1]](diffhunk://#diff-a318676c8d130b0ab61f70731ab38a6d7895481795720cf10c51262bc013d520L24-R24) [[2]](diffhunk://#diff-3c3879ee6981eff1b45e21404927ddee893f33119c584c4c2d428655e9fac979L70-R70) [[3]](diffhunk://#diff-acb27e9b873802d29e92d1e4e19bd64e295ef7c12bbe64993fdbd3eb1b4bba84L164-R181)

**Data Privacy Improvements**

* Added a test to verify that only the last 4 digits of the government ID number are stored in the user's KYC payload, and that the full ID is not retained (`spec/requests/kyc/submissions_spec.rb`).